### PR TITLE
chore: add conductor scripts

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+    "scripts": {
+        "setup": "bun install; for d in .claude .codex .cursor; do [ -d \"$CONDUCTOR_ROOT_PATH/$d\" ] && mkdir -p \"$CONDUCTOR_WORKSPACE_PATH/$d\" && rsync -a \"$CONDUCTOR_ROOT_PATH/$d/.\" \"$CONDUCTOR_WORKSPACE_PATH/$d/\"; done; [ -f \"$CONDUCTOR_ROOT_PATH/.env\" ] && cp \"$CONDUCTOR_ROOT_PATH/.env\" \"$CONDUCTOR_WORKSPACE_PATH/.env\"",
+        "run": "bun run tauri dev"
+    }
+}


### PR DESCRIPTION
Adds conductor.json with setup and run scripts for Conductor workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `conductor.json` to streamline Conductor workflows.
> 
> - Introduces `scripts.setup` to run `bun install` and sync `.claude`, `.codex`, `.cursor`, and `.env` from `CONDUCTOR_ROOT_PATH` to `CONDUCTOR_WORKSPACE_PATH`
> - Adds `scripts.run` to start Tauri in dev mode via `bun run tauri dev`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e5dbfcdd70a15fb58285a04b20add2365b83ac5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added conductor.json with setup and run scripts to standardize Conductor workflow setup and local development.

Setup installs dependencies and syncs .claude, .codex, .cursor, and .env from the root to the workspace. Run starts the Tauri dev server with bun.

<sup>Written for commit 1e5dbfcdd70a15fb58285a04b20add2365b83ac5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

