### PR TITLE
fix: toast styling and stacking

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -41,7 +41,7 @@ export function AppShell({ children }: Props) {
       ) : null}
       {children}
       <DialogHost />
-      <Toaster position="bottom-right" expand richColors closeButton />
+      <Toaster position="bottom-right" closeButton />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Remove color coding from toasts (no more green/yellow/red backgrounds)
- Enable proper toast stacking (3 visible, expand on hover)

## Test plan
- [ ] Trigger multiple toasts and verify they stack
- [ ] Verify toasts use neutral background colors
- [ ] Verify toasts expand on hover

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies toast appearance and behavior.
> 
> - In `AppShell.tsx`, removes `richColors` and `expand` props from `Toaster`; keeps `position="bottom-right"` and `closeButton`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 845ac553cb86e989a3c72f44bae781a448c4135f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed toast color-coding and custom expand behavior so toasts use neutral backgrounds and default stacking.
This makes stacking consistent (three visible, expand on hover) and reduces visual noise.

<sup>Written for commit 845ac553cb86e989a3c72f44bae781a448c4135f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

