### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "augenblick",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "augenblick"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "objc2",
@@ -1608,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "augenblick"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Augenblick",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.sunstory.augenblick",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Version bump across package.json, tauri.conf.json, and Cargo.toml. Also updated Cargo.lock to sync dependencies.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit b32f758cef543956f36ae990d83f81187d00fe80. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the app version to 0.1.4 across JS and Tauri/Rust config files to prepare the next release and keep versioning consistent. Syncs Cargo.lock, including iana-time-zone updated to 0.1.65.

<sup>Written for commit b32f758cef543956f36ae990d83f81187d00fe80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

