### PR TITLE
Fix UTF-8 truncation panic on paste

### DIFF
--- a/src-tauri/src/notes/derive.rs
+++ b/src-tauri/src/notes/derive.rs
@@ -77,7 +77,11 @@ fn truncate(s: String, max_len: usize) -> String {
         return s;
     }
     let mut out = s;
-    out.truncate(max_len);
+    let mut end = max_len.min(out.len());
+    while end > 0 && !out.is_char_boundary(end) {
+        end -= 1;
+    }
+    out.truncate(end);
     out
 }
 
@@ -134,5 +138,16 @@ mod tests {
     fn escaped_heading_prefix() {
         let (title, _) = derive_title_preview("\\# Escaped");
         assert!(title.starts_with('#'));
+    }
+
+    #[test]
+    fn unicode_truncation_no_panic() {
+        let line = "● Jamf “KISS” Setup (mit eurem check_free_space + Live-Check + Zeilenumbrüche)"
+            .repeat(4);
+        let (title, preview) = derive_title_preview(&line);
+        assert!(!title.is_empty());
+        assert!(!preview.is_empty());
+        assert!(title.len() <= 80);
+        assert!(preview.len() <= 140);
     }
 }


### PR DESCRIPTION
Avoid panic when truncating note title/preview with Unicode.
Add regression test for Unicode-heavy paste.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change isolated to string truncation logic plus a regression test; main risk is slight behavior change in where strings are cut for non-ASCII input.
> 
> **Overview**
> Fixes a panic when truncating note `title`/`preview` by making `truncate` UTF-8 safe (backing up to the nearest `char` boundary before truncating).
> 
> Adds a regression test covering Unicode-heavy input to ensure derived `title`/`preview` stay within length limits without crashing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8bbfb7ce52f221596f0f3e95c237bf8a0e71d11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash when pasting Unicode by truncating note titles and previews at valid UTF-8 boundaries. Adds a regression test to cover Unicode-heavy input.

- **Bug Fixes**
  - Updated truncate() to back off from max_len to the nearest char boundary before truncating.
  - Added a Unicode-heavy paste test to ensure no panic and enforce title (<=80) and preview (<=140) limits.

<sup>Written for commit d8bbfb7ce52f221596f0f3e95c237bf8a0e71d11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

