### PR TITLE
Update tray behavior and shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@ It's not about losing information, it's about not drowning in it.
 | Save As         | `⇧⌘S`    |
 | Open/Import     | `⌘O`     |
 | Pin/Unpin       | `⌘P`     |
-| Trash note      | `⌘W`     |
+| Trash note      | `Delete` |
+| Hide window     | `⌘W`     |
 | Command palette | `⌘K`     |
 | Settings        | `⌘,`     |
+
+## Tray
+
+- Left click shows all notes
+- Right click opens the tray menu
 
 
 ## Built With AI

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -30,3 +30,4 @@
 
 ## 2026-01-29
 - Expiry sync: run `expiry_run_now` before initial notes load; schedule next sweep at nearest unpinned note expiry to keep UI list in sync.
+- Tray click: treat any left-click on tray icon as "show all notes" (Cmd modifier not exposed by Tauri tray events).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,6 +286,14 @@ function App() {
       }));
 
       if (disposed) return;
+      registerUnlisten(await listen("tray-show-all", () => {
+        void runOrAlert(async () => {
+          useNotesStore.getState().setViewMode("notes");
+          await showMainWindow();
+        });
+      }));
+
+      if (disposed) return;
       registerUnlisten(await listen<string>("tray-select-note", (event) => {
         const id = event.payload;
         if (!id) return;

--- a/src/routes/pageHotkeys.ts
+++ b/src/routes/pageHotkeys.ts
@@ -123,12 +123,6 @@ export function createPageKeydownHandler(deps: Deps) {
       return;
     }
 
-    if (key === "w") {
-      e.preventDefault();
-      deps.closeCurrent();
-      return;
-    }
-
     if (key === "o") {
       e.preventDefault();
       deps.openMarkdown();


### PR DESCRIPTION
Update tray clicks and menu entries for show-all behavior. Align shortcuts and labels in the app menu and README. Document tray behavior and choices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to tray/menu behavior and keyboard shortcut bindings, with no data model or persistence changes. Main risk is minor UX regressions in shortcut expectations (e.g., `Delete` vs `Cmd+W`) and tray click handling across platforms.
> 
> **Overview**
> Left-clicking the tray icon now emits a new `tray-show-all` event and no longer opens the tray menu; the tray menu also adds an explicit **“Show all notes”** action.
> 
> Keyboard shortcuts and labels are aligned across the app: **trash uses `Delete`** (and the `Cmd+W` close-note binding is removed), and “New note” labeling is normalized; docs (`README.md`, `docs/choices.md`) are updated to describe the tray behavior and shortcut changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ff5d9a1970529f412ec53ee15d3054a6d8d65d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the tray icon more useful and align shortcuts/labels for a simpler, consistent UX. Left‑clicking the tray now shows all notes, and Cmd‑W hides the window while Delete moves a note to Trash.

- **New Features**
  - Tray: Left click shows all notes; right click opens the tray menu; added “Show all notes” menu item.

- **Refactors**
  - Shortcuts: Delete = Trash note; Cmd‑W = Hide window; removed the old “w” handler.
  - Labels: Consistent “New note” casing across the app menu, tray, and README.

<sup>Written for commit 9ff5d9a1970529f412ec53ee15d3054a6d8d65d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

