### PR TITLE
feat(time): smart compound time formatting for expiry display

### DIFF
--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -17,18 +17,24 @@ export function formatRelativeTime(fromMs: number, toMs = Date.now()): string {
 
 export function formatRelativeTimeFromNow(targetMs: number, nowMs = Date.now()): string {
   const deltaMs = targetMs - nowMs;
-  const deltaSeconds = Math.ceil(deltaMs / 1000);
+  if (deltaMs <= 0) return "now";
 
-  if (deltaSeconds <= 0) return "now";
-  if (deltaSeconds < 10) return "in a moment";
-  if (deltaSeconds < 60) return `in ${deltaSeconds}s`;
+  const totalSeconds = Math.floor(deltaMs / 1000);
+  if (totalSeconds < 10) return "in a moment";
 
-  const deltaMinutes = Math.ceil(deltaSeconds / 60);
-  if (deltaMinutes < 60) return `in ${deltaMinutes}m`;
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
 
-  const deltaHours = Math.ceil(deltaMinutes / 60);
-  if (deltaHours < 24) return `in ${deltaHours}h`;
-
-  const deltaDays = Math.ceil(deltaHours / 24);
-  return `in ${deltaDays}d`;
+  if (days > 0) {
+    return hours > 0 ? `in ${days}d ${hours}h` : `in ${days}d`;
+  }
+  if (hours > 0) {
+    return minutes > 0 ? `in ${hours}h ${minutes}m` : `in ${hours}h`;
+  }
+  if (minutes > 0) {
+    return seconds > 0 ? `in ${minutes}m ${seconds}s` : `in ${minutes}m`;
+  }
+  return `in ${seconds}s`;
 }

--- a/src/test/lib/time.test.ts
+++ b/src/test/lib/time.test.ts
@@ -19,13 +19,41 @@ describe("formatRelativeTime", () => {
 });
 
 describe("formatRelativeTimeFromNow", () => {
-  it("formats future times and now", () => {
+  it("formats edge cases", () => {
     const now = 1_000_000;
     expect(formatRelativeTimeFromNow(now - 1_000, now)).toBe("now");
     expect(formatRelativeTimeFromNow(now + 1_000, now)).toBe("in a moment");
     expect(formatRelativeTimeFromNow(now + 10_000, now)).toBe("in 10s");
+  });
+
+  it("formats exact units without trailing zero", () => {
+    const now = 1_000_000;
     expect(formatRelativeTimeFromNow(now + 60_000, now)).toBe("in 1m");
     expect(formatRelativeTimeFromNow(now + 3_600_000, now)).toBe("in 1h");
     expect(formatRelativeTimeFromNow(now + 86_400_000, now)).toBe("in 1d");
+  });
+
+  it("formats compound days + hours", () => {
+    const now = 1_000_000;
+    // 1d 1h = 25h = 90_000_000ms
+    expect(formatRelativeTimeFromNow(now + 90_000_000, now)).toBe("in 1d 1h");
+    // 2d 12h
+    expect(formatRelativeTimeFromNow(now + 216_000_000, now)).toBe("in 2d 12h");
+  });
+
+  it("formats compound hours + minutes", () => {
+    const now = 1_000_000;
+    // 2h 3m = 7380s = 7_380_000ms
+    expect(formatRelativeTimeFromNow(now + 7_380_000, now)).toBe("in 2h 3m");
+    // 5h 30m
+    expect(formatRelativeTimeFromNow(now + 19_800_000, now)).toBe("in 5h 30m");
+  });
+
+  it("formats compound minutes + seconds", () => {
+    const now = 1_000_000;
+    // 12m 34s = 754s = 754_000ms
+    expect(formatRelativeTimeFromNow(now + 754_000, now)).toBe("in 12m 34s");
+    // 1m 30s
+    expect(formatRelativeTimeFromNow(now + 90_000, now)).toBe("in 1m 30s");
   });
 });


### PR DESCRIPTION
Improves the "Trashed in X" countdown to show more precise, nuanced time formats.

## Description
- Shows compound units based on magnitude: days+hours, hours+minutes, or minutes+seconds
- Omits zero sub-units for cleaner display (e.g., "in 2d" not "in 2d 0h")
- ExpiryRing now uses adaptive refresh (1s when <1h remaining, 60s otherwise)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/utility changes: updates countdown string formatting and refresh cadence, with minimal impact beyond time display and a small increase in re-render frequency when near expiry.
> 
> **Overview**
> Improves the expiry countdown tooltip to show **more precise, compound relative time** (e.g., `in 2h 3m`, `in 12m 34s`) while omitting zero sub-units, via a rewrite of `formatRelativeTimeFromNow`.
> 
> Updates `ExpiryRing` to **refresh adaptively** (every 1s when <1h remaining, otherwise every 60s) so the new seconds-level countdown stays accurate, and expands unit tests to cover the new formatting cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c21cb8ea4e3db4358bb9e79ec760be16207a4588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the “Trashed in …” countdown with smarter, compound time formatting (days+hours, hours+minutes, minutes+seconds) and cleaner output. ExpiryRing now refreshes every second when under 1 hour, otherwise once a minute, so the tooltip stays accurate without extra noise.

<sup>Written for commit c21cb8ea4e3db4358bb9e79ec760be16207a4588. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

