### PR TITLE
test: fix failing tests and improve branch coverage to 80%

### DIFF
--- a/src/test/features/Editor.test.tsx
+++ b/src/test/features/Editor.test.tsx
@@ -223,6 +223,103 @@ describe("Editor", () => {
     await unmount();
   });
 
+  it("shows bubble menu when text is selected", async () => {
+    const onChange = vi.fn();
+
+    const { unmount } = await render(
+      React.createElement((await import("@/features/editor/Editor")).Editor, {
+        value: "hello",
+        onChange,
+      }),
+    );
+
+    const shouldShow = bubbleProps?.shouldShow;
+    expect(
+      shouldShow({
+        state: {
+          selection: { empty: false, from: 0, to: 5 },
+          doc: { textContent: "hello", textBetween: () => "hello" },
+          schema: { marks: { link: { name: "link" } } },
+        },
+      }),
+    ).toBe(true);
+
+    await unmount();
+  });
+
+  it("hides bubble menu when selection is whitespace only", async () => {
+    const onChange = vi.fn();
+
+    const { unmount } = await render(
+      React.createElement((await import("@/features/editor/Editor")).Editor, {
+        value: "hello",
+        onChange,
+      }),
+    );
+
+    const shouldShow = bubbleProps?.shouldShow;
+    expect(
+      shouldShow({
+        state: {
+          selection: { empty: false, from: 0, to: 3 },
+          doc: { textContent: "   world", textBetween: () => "   " },
+          schema: { marks: { link: { name: "link" } } },
+        },
+      }),
+    ).toBe(false);
+
+    await unmount();
+  });
+
+  it("shows bubble menu when cursor is on link mark", async () => {
+    const onChange = vi.fn();
+
+    const { unmount } = await render(
+      React.createElement((await import("@/features/editor/Editor")).Editor, {
+        value: "hello",
+        onChange,
+      }),
+    );
+
+    const shouldShow = bubbleProps?.shouldShow;
+    const linkMark = { name: "link" };
+    expect(
+      shouldShow({
+        state: {
+          selection: { empty: true, from: 2, to: 2, $from: { marks: () => [{ type: linkMark }] } },
+          doc: { textContent: "hello", textBetween: () => "" },
+          schema: { marks: { link: linkMark } },
+        },
+      }),
+    ).toBe(true);
+
+    await unmount();
+  });
+
+  it("hides bubble menu when no link mark in schema", async () => {
+    const onChange = vi.fn();
+
+    const { unmount } = await render(
+      React.createElement((await import("@/features/editor/Editor")).Editor, {
+        value: "hello",
+        onChange,
+      }),
+    );
+
+    const shouldShow = bubbleProps?.shouldShow;
+    expect(
+      shouldShow({
+        state: {
+          selection: { empty: true, from: 2, to: 2, $from: { marks: () => [] } },
+          doc: { textContent: "hello", textBetween: () => "" },
+          schema: { marks: {} },
+        },
+      }),
+    ).toBe(false);
+
+    await unmount();
+  });
+
   it("opens links only on modifier click", async () => {
     const onChange = vi.fn();
     const openSpy = vi.spyOn(window, "open").mockReturnValue(null);

--- a/src/test/features/Sidebar.test.tsx
+++ b/src/test/features/Sidebar.test.tsx
@@ -187,7 +187,7 @@ describe("Sidebar", () => {
     expect(container.textContent).toContain("Trash is empty");
 
     const emptyButton = Array.from(container.querySelectorAll("button")).find((btn) =>
-      btn.textContent?.includes("Empty Trash"),
+      btn.textContent?.includes("Empty trash"),
     ) as HTMLButtonElement | undefined;
     expect(emptyButton?.disabled).toBe(true);
 
@@ -219,7 +219,7 @@ describe("Sidebar", () => {
     );
 
     const emptyButton = Array.from(container.querySelectorAll("button")).find((btn) =>
-      btn.textContent?.includes("Empty Trash"),
+      btn.textContent?.includes("Empty trash"),
     ) as HTMLButtonElement | undefined;
     emptyButton?.click();
     expect(onClearTrash).toHaveBeenCalled();

--- a/src/test/lib/tauriShim.test.ts
+++ b/src/test/lib/tauriShim.test.ts
@@ -258,4 +258,9 @@ describe("tauri web shim", () => {
     const settings = (await invoke("settings_get_all")) as { theme: string };
     expect(settings.theme).toBe("dark");
   });
+
+  it("silently returns for note_set_active on missing note", async () => {
+    const result = await invoke("note_set_active", { id: "nonexistent" });
+    expect(result).toBeUndefined();
+  });
 });

--- a/src/test/routes/pageHotkeys.test.ts
+++ b/src/test/routes/pageHotkeys.test.ts
@@ -292,4 +292,74 @@ describe("pageHotkeys", () => {
     handler(e);
     expect(deps.closeCurrent).toHaveBeenCalled();
   });
+
+  it("creates note on Cmd+N", () => {
+    const deps = {
+      getNotesSnapshot: () => ({ list: { active: [], trashed: [] }, selectedId: null, viewMode: "notes" as const }),
+      getSelectedId: () => null,
+      toggleCommandPalette: vi.fn(),
+      closeCommandPalette: vi.fn(),
+      openSettings: vi.fn(),
+      setViewMode: vi.fn(),
+      createNote: vi.fn(),
+      togglePinCurrent: vi.fn(),
+      closeCurrent: vi.fn(),
+      openMarkdown: vi.fn(),
+      saveCurrent: vi.fn(),
+      saveAs: vi.fn(),
+      selectNote: vi.fn(),
+      undoReorder: vi.fn(),
+      redoReorder: vi.fn(),
+    };
+
+    const handler = createPageKeydownHandler(deps);
+    const e = {
+      key: "n",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      target: document.body,
+      preventDefault: vi.fn(),
+      altKey: false,
+    } as unknown as KeyboardEvent;
+
+    handler(e);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(deps.createNote).toHaveBeenCalled();
+  });
+
+  it("toggles pin on Cmd+P", () => {
+    const deps = {
+      getNotesSnapshot: () => ({ list: { active: [], trashed: [] }, selectedId: null, viewMode: "notes" as const }),
+      getSelectedId: () => null,
+      toggleCommandPalette: vi.fn(),
+      closeCommandPalette: vi.fn(),
+      openSettings: vi.fn(),
+      setViewMode: vi.fn(),
+      createNote: vi.fn(),
+      togglePinCurrent: vi.fn(),
+      closeCurrent: vi.fn(),
+      openMarkdown: vi.fn(),
+      saveCurrent: vi.fn(),
+      saveAs: vi.fn(),
+      selectNote: vi.fn(),
+      undoReorder: vi.fn(),
+      redoReorder: vi.fn(),
+    };
+
+    const handler = createPageKeydownHandler(deps);
+    const e = {
+      key: "p",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      target: document.body,
+      preventDefault: vi.fn(),
+      altKey: false,
+    } as unknown as KeyboardEvent;
+
+    handler(e);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(deps.togglePinCurrent).toHaveBeenCalled();
+  });
 });

--- a/src/test/stores/dialogStore.test.ts
+++ b/src/test/stores/dialogStore.test.ts
@@ -51,4 +51,12 @@ describe("dialogStore", () => {
     resolveDialog("cancel");
     await expect(cancelPromise).resolves.toBe(false);
   });
+
+  it("confirmDialog uses destructive variant when specified", async () => {
+    const promise = confirmDialog({ title: "Delete?", destructive: true });
+    const req = useDialogStore.getState().request;
+    expect(req?.actions[0]?.variant).toBe("destructive");
+    resolveDialog("confirm");
+    await promise;
+  });
 });


### PR DESCRIPTION
## TLDR
Fixes 3 failing tests and adds 10 new tests to bring branch coverage from 78.92% to 80.3%.

## Description
- Fix Sidebar tests by correcting button text mismatch ("Empty Trash" → "Empty trash")
- Fix notesStore timeout by adding microtask flush for fake timer promise handling
- Add tests for hotkeys (Cmd+N, Cmd+P), dialog destructive variant, error catch blocks, and Editor BubbleMenu visibility branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to test updates and added assertions; main risk is tightening expectations that could make tests brittle if UI text or logging changes again.
> 
> **Overview**
> Fixes test expectations and timing to stabilize the suite (e.g., Sidebar button label casing and flushing fake timers/microtasks in the expiry sweep test).
> 
> Adds new tests to cover previously untested branches: editor BubbleMenu `shouldShow` conditions, `Cmd+N`/`Cmd+P` hotkeys, `confirmDialog` destructive variant wiring, tauri shim `note_set_active` behavior for missing notes, and error-path logging for draft autosave and expiry sweeps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3eeafab30129bc366e3de5c77b9f1c3c2d440dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 3 failing tests and adds 10 tests to raise branch coverage from 78.92% to 80.3%. Stabilizes sidebar and notes store tests and covers key editor and hotkey paths.

- **Bug Fixes**
  - Sidebar tests: corrected button label match ("Empty Trash" → "Empty trash").
  - notesStore tests: added microtask flush to fix fake-timer promise timing.

- **Test Coverage**
  - Editor: bubble menu visibility for selected text, whitespace-only selection, link mark at cursor, and missing link schema.
  - Hotkeys: Cmd+N creates a note; Cmd+P toggles pin (with preventDefault).
  - Dialog and error paths: destructive confirmDialog variant; notesStore logs on draft auto-save and expiry sweep failures; tauriShim no-op on note_set_active for missing note.

<sup>Written for commit d3eeafab30129bc366e3de5c77b9f1c3c2d440dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

